### PR TITLE
Feature/login

### DIFF
--- a/src/main/java/com/scope/socialboardweb/config/WebConfig.java
+++ b/src/main/java/com/scope/socialboardweb/config/WebConfig.java
@@ -1,7 +1,8 @@
 package com.scope.socialboardweb.config;
 
 import com.scope.socialboardweb.interceptor.AuthorizationInterceptor;
-import com.scope.socialboardweb.utils.annotation.resolver.RequestAttributeArgumentResolver;
+import com.scope.socialboardweb.utils.resolver.RequestAttributeArgumentResolver;
+import com.scope.socialboardweb.utils.resolver.UserRequestArgumentResolver;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
@@ -19,6 +20,9 @@ public class WebConfig implements WebMvcConfigurer {
 
     @Autowired
     private AuthorizationInterceptor authorizationInterceptor;
+
+    @Autowired
+    private UserRequestArgumentResolver userRequestArgumentResolver;
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {
@@ -38,5 +42,6 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(requestAttributeArgumentResolver);
+        resolvers.add(userRequestArgumentResolver);
     }
 }

--- a/src/main/java/com/scope/socialboardweb/controller/test/GetUserFromTokenTestController.java
+++ b/src/main/java/com/scope/socialboardweb/controller/test/GetUserFromTokenTestController.java
@@ -1,7 +1,9 @@
 package com.scope.socialboardweb.controller.test;
 
 import com.scope.socialboardweb.dto.ResponseDto;
+import com.scope.socialboardweb.dto.UserLoginDto;
 import com.scope.socialboardweb.dto.UserRequestDto;
+import com.scope.socialboardweb.utils.annotation.LoginUser;
 import com.scope.socialboardweb.utils.annotation.RequestAttribute;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -14,8 +16,16 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class GetUserFromTokenTestController {
 
+    /**
+     * @RequestAttribute("loginUser") 나
+     * @LoginUser 모두 동일한 기능을 한다.
+     */
+
     @PostMapping("/user")
-    ResponseDto test(@RequestAttribute("loginUser") UserRequestDto userRequestDto) {
+    ResponseDto test(
+//        @RequestAttribute("loginUser") UserRequestDto userRequestDto
+        @LoginUser UserRequestDto userRequestDto
+        ) {
         log.info("Login User Id: {}", userRequestDto.getUserId());
         log.info("Login User Nickname: {}", userRequestDto.getNickname());
         log.info("Login User Password: {}", userRequestDto.getPassword());

--- a/src/main/java/com/scope/socialboardweb/utils/annotation/LoginUser.java
+++ b/src/main/java/com/scope/socialboardweb/utils/annotation/LoginUser.java
@@ -1,0 +1,9 @@
+package com.scope.socialboardweb.utils.annotation;
+
+import java.lang.annotation.*;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface LoginUser {
+}

--- a/src/main/java/com/scope/socialboardweb/utils/resolver/RequestAttributeArgumentResolver.java
+++ b/src/main/java/com/scope/socialboardweb/utils/resolver/RequestAttributeArgumentResolver.java
@@ -1,4 +1,4 @@
-package com.scope.socialboardweb.utils.annotation.resolver;
+package com.scope.socialboardweb.utils.resolver;
 
 import com.scope.socialboardweb.utils.annotation.RequestAttribute;
 import org.springframework.core.MethodParameter;

--- a/src/main/java/com/scope/socialboardweb/utils/resolver/UserRequestArgumentResolver.java
+++ b/src/main/java/com/scope/socialboardweb/utils/resolver/UserRequestArgumentResolver.java
@@ -1,0 +1,30 @@
+package com.scope.socialboardweb.utils.resolver;
+
+import com.scope.socialboardweb.dto.UserRequestDto;
+import com.scope.socialboardweb.utils.annotation.LoginUser;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import javax.servlet.http.HttpServletRequest;
+
+@Component
+public class UserRequestArgumentResolver implements HandlerMethodArgumentResolver {
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        boolean isCorrectParameterType = parameter.getParameterType().equals(UserRequestDto.class);
+        boolean isCorrectAnnotation = parameter.hasParameterAnnotation(LoginUser.class);
+
+        return isCorrectParameterType && isCorrectAnnotation;
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        HttpServletRequest httpServletRequest = webRequest.getNativeRequest(HttpServletRequest.class);
+        Object loginUser = httpServletRequest.getAttribute("loginUser");
+        return loginUser;
+    }
+}


### PR DESCRIPTION
기존에 컨트롤러 메서드에서 로그인된 사용자 정보를 받기 위해, `@RequestAttribute("loginUser")` 를 사용했던 것과 다르게  
`@LoginUser` 를 통해서도 가능하도록 애너테이션을 추가했습니다.  

예를 들자면 아래와 같아요.  

- 기존 방식
  - `@RequestAttribute("loginUser")`
- 추가된 방식
  - `@LoginUser`

위 두 애너테이션 모두 사용 가능하며, 같은 기능을 합니다.  

하지만, 속성값으로 `loginUser` 를 추가해야 하는 번거로움을 없애고, 보다 직관적인 애너테이션 이름을 사용했습니다.  

> 자세한 것은 `GetUserFromTokenTestController` 클래스의 `test()` 메서드를 참고해주세요.