### PR TITLE
Fix: JWT 인터셉터 적용 범위 수정

### DIFF
--- a/src/main/java/com/scope/socialboardweb/config/WebConfig.java
+++ b/src/main/java/com/scope/socialboardweb/config/WebConfig.java
@@ -35,8 +35,8 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(authorizationInterceptor)
-            .addPathPatterns("/**")
-            .excludePathPatterns("/api/user/signup/**", "/api/user/signin/**", "/test/token", "api/auth/**", "/error/**");
+            .addPathPatterns("/api/**", "/test/user")
+            .excludePathPatterns("/api/user/signup/**", "/api/user/signin/**", "/api/auth/**");
     }
 
     @Override


### PR DESCRIPTION
`/api` 로 시작하는 URL에만, JWT 인터셉터가 적용되도록 수정함.

> `/api/user/signin`, `/api/user/signup`, `/api/auth` 는 제외됨.