### PR TITLE
JPA 동시성 문제 해결

### DIFF
--- a/src/main/java/com/scope/socialboardweb/repository/custom/CustomUserRepository.java
+++ b/src/main/java/com/scope/socialboardweb/repository/custom/CustomUserRepository.java
@@ -1,11 +1,13 @@
 package com.scope.socialboardweb.repository.custom;
 
 import com.scope.socialboardweb.domain.User;
+import lombok.Getter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 
 import javax.persistence.EntityManager;
 import javax.persistence.NoResultException;
+import javax.persistence.PersistenceContext;
 import javax.persistence.TypedQuery;
 import java.util.List;
 import java.util.Optional;
@@ -13,7 +15,7 @@ import java.util.Optional;
 @Repository
 public class CustomUserRepository {
 
-    @Autowired
+    @PersistenceContext
     private EntityManager em;
 
     //저장 관련

--- a/src/test/java/com/scope/socialboardweb/repository/custom/CustomUserRepositoryTest.java
+++ b/src/test/java/com/scope/socialboardweb/repository/custom/CustomUserRepositoryTest.java
@@ -21,12 +21,9 @@ import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-//@ExtendWith(SpringExtension.class)
-//@Import(CustomUserRepository.class)
-//@ActiveProfiles("test")
-//@DataJpaTest
-@SpringBootTest
-@Transactional
+@Import(CustomUserRepository.class)
+@ActiveProfiles("test")
+@DataJpaTest
 class CustomUserRepositoryTest {
 
     @Autowired


### PR DESCRIPTION
`@Autowired` 로 엔티티매니저를 가져왔었으나, 현재는 `@PersistenceContext` 로 가져오도록 수정함.  
이를 통해, 동시성 문제를 해결할 수 있음.

그리고 Repository 클래스 테스트코드를 다시 수정하여, 배포가 잘되는지 확인해봄.